### PR TITLE
Improved audio player interface

### DIFF
--- a/pkgs/apps/AudioPlayer.js
+++ b/pkgs/apps/AudioPlayer.js
@@ -7,16 +7,21 @@ export default {
     let wrapper; // Lib.html | undefined
     let MyWindow;
 
+    const Html = (await import("https://unpkg.com/@datkat21/html")).default;
+
     console.log("Hello from example package", Root.Lib);
 
     Root.Lib.setOnEnd(function () {
       MyWindow.close();
     });
+
     const Win = (await Root.Lib.loadLibrary("WindowSystem")).win;
 
     MyWindow = new Win({
       title: "Audio Player",
       pid: Root.PID,
+      width: 854,
+      height: 480,
       onclose: () => {
         Root.Lib.onEnd();
       },
@@ -34,8 +39,28 @@ export default {
 
     const Sidebar = await Root.Lib.loadComponent("Sidebar");
 
+    // this function won't return a module
+    async function loadScript(url) {
+      // script probably already exists
+      if (Html.qs('script[src="' + url + '"]')) {
+        return false;
+      }
+
+      // make new script
+      new Html("script").html(await (await fetch(url)).text()).appendTo("body");
+      return true;
+    }
+
+    await loadScript(
+      "https://cdnjs.cloudflare.com/ajax/libs/jsmediatags/3.9.5/jsmediatags.min.js"
+    );
+
+    let jMediaTags = window.jsmediatags;
+    console.log(jMediaTags);
+
     // this function opens the file and changes the title to the file name,
     // we load the file into a buffer
+    let fileName = "";
     async function openFile(path) {
       let file;
       if (path) file = path;
@@ -43,8 +68,9 @@ export default {
       if (file === false) return;
       let result = updateAudio(await vfs.readFile(file));
       if (result === false) return;
+      fileName = file.split("/").pop();
       MyWindow.window.querySelector(".win-titlebar .title").innerText =
-        "Audio Player - " + file.split("/").pop();
+        "Audio Player - " + fileName;
       MyWindow.focus();
     }
 
@@ -71,21 +97,47 @@ export default {
 
     // creates the wrapper that the image is in
     let vidWrapper = new Root.Lib.html("div")
-      .class("ovh", "fg", "fc", "row")
+      .class("ovh", "fg", "fc")
+      .styleJs({
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        width: "100%",
+        height: "100%",
+      })
       .appendTo(wrapper);
 
     // creates the actual img element
-    let img = new Root.Lib.html("audio")
+    let metaDataDiv = new Root.Lib.html("div").appendTo(vidWrapper).styleJs({
+      display: "flex",
+      gap: "25px",
+      alignItems: "center",
+      justifyContent: "center",
+    });
+    let img = new Root.Lib.html("img").appendTo(metaDataDiv).styleJs({
+      objectFit: "cover",
+      width: "200px",
+      height: "200px",
+      borderRadius: "5px",
+    });
+    let texts = new Root.Lib.html("div").appendTo(metaDataDiv).styleJs({
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "center",
+    });
+    new Root.Lib.html("br").appendTo(vidWrapper);
+    new Root.Lib.html("br").appendTo(vidWrapper);
+    let audio = new Root.Lib.html("audio")
       .appendTo(vidWrapper)
       .style({
-        width: "100%",
+        width: "80%",
         "object-fit": "contain",
         border: "none",
       })
-      .attr({ draggable: "false", controls: 'on' });
+      .attr({ draggable: "false", controls: "on" });
 
     // updates the video on the next load
-    function updateAudio(content) {
+    async function updateAudio(content) {
       if (!content.startsWith("data:audio/") && !content.startsWith("blob:")) {
         Root.Modal.alert("Error", "This does not look like an audio file").then(
           (_) => {
@@ -94,7 +146,32 @@ export default {
         );
         return false;
       }
-      img.elm.src = content;
+      setTimeout(async () => {
+        console.log(fileName);
+        new Root.Lib.html("h1").appendTo(texts).text("Now Playing");
+        new Root.Lib.html("p").appendTo(texts).text(fileName);
+        const audioBlob = await (await fetch(content)).blob();
+        jsmediatags.read(audioBlob, {
+          onSuccess: function (tag) {
+            // console.log(tag);
+            if ("picture" in tag.tags) {
+              console.log(tag.tags.picture);
+              let buf = new Uint8Array(tag.tags.picture.data);
+              let blob = new Blob([buf]);
+              console.log(blob);
+              img.elm.src = URL.createObjectURL(blob);
+            } else {
+              img.cleanup();
+            }
+          },
+          onError: function (error) {
+            console.log(error);
+            img.cleanup();
+          },
+        });
+      }, 700);
+      audio.elm.src = content;
+      audio.elm.play();
     }
 
     return Root.Lib.setupReturns((m) => {


### PR DESCRIPTION
While I work, I always have music on, whether it is playing on YouTube or offline. While testing Pluto, I uploaded some of the songs I have downloaded on my computer, and decided to try the built-in audio player. The interface is pretty lackluster. Audio doesn't autoplay, even though it can and usually should, the window is too small, and the interface seems to be just a single Audio element slapped into a window. 

![msedge_Ae1euHoTb1](https://github.com/zeondev/pluto/assets/86519653/61d473a8-ff41-48f1-910d-3eab6b30fd12)

And so, I decided to open up this pull request to pretty the audio player up. It now displays an album cover, and the audio now autoplays! 

![msedge_8l7WS24Jwc](https://github.com/zeondev/pluto/assets/86519653/fb87d40a-3d1c-495f-bc31-1b0ba5781da5)

Demo video here: 

https://github.com/zeondev/pluto/assets/86519653/8dba6843-f1a4-471a-a062-def57e7ee02b

