### PR TITLE
Increase support for BLOBs and add additional VFS API.

### DIFF
--- a/docs/virtualFS.html
+++ b/docs/virtualFS.html
@@ -1306,6 +1306,8 @@ Helper function to get the parent folder of a given path</li>
 function to tell you if stored data is a file or a folder</li>
 <li><code class="notranslate">async readFile(path, fsObject = this.fileSystem, bypass = false)</code><br>
 Function to get the contents of a file at a given path</li>
+<li><code class="notranslate">async readFileAsBuffer(path, fsObject = this.fileSystem)</code><br>
+Same as readFile but for non-text objects (uploaded with non text/ mime type) returns Uint8Array</li>
 <li><code class="notranslate">async writeFile(path, contents, fsObject = this.fileSystem)</code><br>
 Function to write to a file at a given path</li>
 <li><code class="notranslate">async createFolder(path, fsObject = this.fileSystem)</code><br>

--- a/docs/virtualFS.md
+++ b/docs/virtualFS.md
@@ -58,6 +58,8 @@ Vfs functions are found as below. Some are documented, others are not
   function to tell you if stored data is a file or a folder
 - `async readFile(path, fsObject = this.fileSystem, bypass = false)`
   Function to get the contents of a file at a given path
+- `async readFileAsBuffer(path, fsObject = this.fileSystem)`
+  Same as readFile but for non-text objects (uploaded with non text/ mime type) returns Uint8Array.
 - `async writeFile(path, contents, fsObject = this.fileSystem)`
   Function to write to a file at a given path
 - `async createFolder(path, fsObject = this.fileSystem)`

--- a/pkgs/apps/FileManager.js
+++ b/pkgs/apps/FileManager.js
@@ -125,7 +125,7 @@ export default {
               );
             let text = await vfs.readFile(selectedItem, undefined);
 
-            if (text.startsWith('blob:')) {
+            if (text.startsWith('blob:') || text.startsWith('data:')) {
               var element = document.createElement("a");
               element.setAttribute("href", text);
               element.setAttribute("download", selectedItem.split("/").pop());
@@ -164,11 +164,7 @@ export default {
               var file = e.target.files[0];
               var reader = new FileReader();
 
-              if (
-                file.type.startsWith("image") ||
-                file.type.startsWith("audio") ||
-                file.type.startsWith("video")
-              ) {
+              if (!file.type.startsWith("text")) {
                 console.log(file);
                 // read as arraybuffer; store as base64
                 // reader.readAsDataURL(file);

--- a/pkgs/lib/VirtualFS.js
+++ b/pkgs/lib/VirtualFS.js
@@ -168,6 +168,19 @@ const Vfs = {
       return resolve(current);
     });
   },
+  // Read a file and return it as an uint8array
+  async readFileAsBuffer(path, fsObject = this.fileSystem) {
+    return new Promise(async (resolve, reject) => {
+      let data = await this.readFile(path, fsObject);
+      if (data === null) return resolve(null);
+      if (data.startsWith("data:") || data.startsWith("blob:")) {
+        let blob = await fetch(data).then((r) => r.blob()); // This works and I dont like it.
+        let buffer = await blob.arrayBuffer();
+        return resolve(new Uint8Array(buffer));
+      }
+      return resolve(null);
+    })
+  },
   // Function to write to a file at a given path
   async writeFile(path, contents, fsObject = this.fileSystem) {
     if (typeof contents !== "string")


### PR DESCRIPTION
- Fixed download so `blob:` and `data:` are checked to verify if the object is binary.
- Refactored upload script to only treat text as text
- Added additional VFS function `readFileAsBuffer` for returning buffer data from blob files.
- Updated docs

Opening non-mapped binary files would open them in notepad revealing the base64 blob instead of the raw data, which could be an issue.